### PR TITLE
feat: backtrace-aware error formatting with simplified, readable traces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,14 @@ pretty = ["dep:cli-boxes", "dep:colored", "dep:textwrap"]
 serde = ["dep:serde"]
 backtraces = []
 force_backtraces = ["backtraces"]
+
+[[example]]
+name = "default"
+
+[[example]]
+name = "pretty"
+required-features = ["pretty"]
+
+[[example]]
+name = "backtraces"
+required-features = ["pretty", "force_backtraces"]

--- a/examples/backtraces.rs
+++ b/examples/backtraces.rs
@@ -1,0 +1,36 @@
+//! Previews both the default and pretty output formats with backtraces.
+//!
+//! Requires the `pretty` and `force_backtraces` features. Run with:
+//!
+//! ```sh
+//! cargo run --example backtraces --features pretty,force_backtraces
+//! ```
+
+fn main() {
+    let err = build_error();
+
+    println!("== Default output with backtraces ==\n");
+    println!("{}\n", err.message_with_backtrace());
+
+    println!("== Pretty output with backtraces ==\n");
+    println!("{}", human_errors::pretty_with_backtraces(&err));
+}
+
+/// Builds a representative, multi-layered error for demonstration purposes.
+///
+/// Each layer captures its own backtrace (when the `force_backtraces` feature
+/// is enabled), which the output formats render recursively.
+fn build_error() -> human_errors::Error {
+    human_errors::wrap_user(
+        human_errors::wrap_system(
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "os error 13: permission denied",
+            ),
+            "We were unable to read the configuration file at /etc/demo/config.yml due to an I/O failure.",
+            &["Ensure the application has permission to read the file and that the file exists."],
+        ),
+        "We could not load your configuration.",
+        &["Check that the --config option points to a readable file."],
+    )
+}

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -1,0 +1,31 @@
+//! Previews the default (plain-text) error output.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example default
+//! ```
+
+fn main() {
+    let err = build_error();
+
+    // The `Display` implementation (and `Error::message`) produces the
+    // default, human-readable representation of the error.
+    println!("{err}");
+}
+
+/// Builds a representative, multi-layered error for demonstration purposes.
+fn build_error() -> human_errors::Error {
+    human_errors::wrap_user(
+        human_errors::wrap_system(
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "os error 13: permission denied",
+            ),
+            "Failed to read the configuration file at /etc/demo/config.yml.",
+            &["Ensure the application has permission to read the file."],
+        ),
+        "We could not load your configuration.",
+        &["Check that the --config option points to a readable file."],
+    )
+}

--- a/examples/pretty.rs
+++ b/examples/pretty.rs
@@ -1,0 +1,31 @@
+//! Previews the pretty (CLI-formatted) error output.
+//!
+//! Requires the `pretty` feature. Run with:
+//!
+//! ```sh
+//! cargo run --example pretty --features pretty
+//! ```
+
+fn main() {
+    let err = build_error();
+
+    // `pretty` renders a richly formatted view of the error, its causal chain
+    // and the aggregated advice for the user.
+    println!("{}", human_errors::pretty(&err));
+}
+
+/// Builds a representative, multi-layered error for demonstration purposes.
+fn build_error() -> human_errors::Error {
+    human_errors::wrap_user(
+        human_errors::wrap_system(
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "os error 13: permission denied",
+            ),
+            "Failed to read the configuration file at /etc/demo/config.yml.",
+            &["Ensure the application has permission to read the file."],
+        ),
+        "We could not load your configuration.",
+        &["Check that the --config option points to a readable file."],
+    )
+}

--- a/src/backtraces.rs
+++ b/src/backtraces.rs
@@ -1,0 +1,268 @@
+//! Parsing and simplification of captured backtraces for display.
+//!
+//! This module is only compiled when the `backtraces` feature is enabled. It is
+//! responsible for collecting the backtraces recorded by an [`Error`] and its
+//! causal chain, and for turning each captured [`std::backtrace::Backtrace`]
+//! into a concise, readable rendering by trimming noise frames and stripping
+//! redundant file paths.
+
+use super::Error;
+
+/// Symbol prefixes whose frames are dropped while they appear contiguously at
+/// the top (innermost end) of a backtrace.
+///
+/// These frames belong to the machinery which captures the backtrace and to
+/// this crate's own error constructors, none of which are useful when
+/// diagnosing where an error actually originated.
+const INITIAL_SKIP_PREFIXES: &[&str] = &["std::backtrace", "human_errors"];
+
+/// Symbol prefixes whose frames retain their function name but have their file
+/// path (the `at <path>` line) removed to reduce noise.
+const HIDE_PATH_PREFIXES: &[&str] = &["core::", "std::"];
+
+/// The standard library symbol which marks the boundary between user code and
+/// the runtime/OS bootstrap that invoked it. Frames from this point toward the
+/// bottom (outermost end) of the stack are dropped.
+const RUNTIME_BOUNDARY_MARKER: &str = "std::sys::backtrace::__rust_begin_short_backtrace";
+
+/// A single frame parsed from a backtrace's textual rendering.
+struct BacktraceFrame<'a> {
+    index: usize,
+    symbol: &'a str,
+    location: Option<&'a str>,
+}
+
+/// Collects the captured backtraces for an error and its causal chain.
+///
+/// Walks the error and each causal [`Error`] which recorded a backtrace,
+/// pairing every captured backtrace with the description of the error it
+/// belongs to. Errors without a successfully captured backtrace are skipped.
+/// Each backtrace is simplified for readability (see [`simplify`]).
+pub(crate) fn collect(error: &Error) -> Vec<(String, String)> {
+    let mut backtraces = Vec::new();
+
+    if let Some(backtrace) = captured(error) {
+        backtraces.push((error.description(), simplify(backtrace)));
+    }
+
+    let mut cause: Option<&(dyn std::error::Error + 'static)> = Some(error.error.as_ref());
+    while let Some(err) = cause {
+        if let Some(err) = err.downcast_ref::<Error>() {
+            if let Some(backtrace) = captured(err) {
+                backtraces.push((err.description(), simplify(backtrace)));
+            }
+        }
+
+        cause = err.source();
+    }
+
+    backtraces
+}
+
+/// Returns the backtrace captured for `error`, but only when a stack trace was
+/// actually recorded (rather than being disabled or unsupported).
+fn captured(error: &Error) -> Option<&std::backtrace::Backtrace> {
+    error
+        .backtrace
+        .as_ref()
+        .filter(|backtrace| backtrace.status() == std::backtrace::BacktraceStatus::Captured)
+}
+
+/// Simplifies a captured [backtrace](std::backtrace::Backtrace) for display.
+///
+/// The formatted output of the backtrace is reduced by:
+///
+/// - Skipping the backtrace-capture (`std::backtrace*`) and `human_errors::*`
+///   frames at the top of the stack, so the trace starts at the caller which
+///   created the error.
+/// - Dropping the runtime and OS bootstrap frames at the bottom of the stack,
+///   so the trace ends where user code begins executing.
+/// - Removing the file path information from `core::*` and `std::*` frames,
+///   which are rarely useful and add significant noise.
+///
+/// Wherever frames are skipped, a `... skipped N frames ...` annotation is
+/// emitted in their place. Remaining frames retain their original offsets. If
+/// nothing survives the filtering, the original (unfiltered) rendering is
+/// returned.
+fn simplify(backtrace: &std::backtrace::Backtrace) -> String {
+    simplify_text(&backtrace.to_string())
+}
+
+/// Applies the backtrace simplification rules to the textual rendering of a
+/// backtrace. See [`simplify`] for the rules which are applied.
+fn simplify_text(raw: &str) -> String {
+    let frames = parse_frames(raw);
+    if frames.is_empty() {
+        return raw.to_string();
+    }
+
+    // Drop the runtime/OS bootstrap frames at the bottom of the stack: everything
+    // from the point where the standard library begins executing user code.
+    let end = frames
+        .iter()
+        .position(|frame| frame.symbol.contains(RUNTIME_BOUNDARY_MARKER))
+        .unwrap_or(frames.len());
+    let bottom_skipped = frames.len() - end;
+
+    // Drop the backtrace-capture and `human_errors::*` frames at the top of the
+    // stack, so the trace starts at the caller which created the error.
+    let start = frames[..end]
+        .iter()
+        .position(|frame| !starts_with_any(frame.symbol, INITIAL_SKIP_PREFIXES))
+        .unwrap_or(end);
+    let top_skipped = start;
+
+    let frames = &frames[start..end];
+    if frames.is_empty() {
+        return raw.to_string();
+    }
+
+    let mut output = String::new();
+
+    if top_skipped > 0 {
+        output.push_str(&format!("    ... skipped {top_skipped} frames ...\n"));
+    }
+
+    for frame in frames {
+        output.push_str(&format!("{:>2}: {}\n", frame.index, frame.symbol));
+
+        if let Some(location) = frame.location {
+            if !starts_with_any(frame.symbol, HIDE_PATH_PREFIXES) {
+                output.push_str(&format!("    {location}\n"));
+            }
+        }
+    }
+
+    if bottom_skipped > 0 {
+        output.push_str(&format!("    ... skipped {bottom_skipped} frames ...\n"));
+    }
+
+    output
+}
+
+/// Parses the textual rendering of a backtrace into its individual frames.
+fn parse_frames(raw: &str) -> Vec<BacktraceFrame<'_>> {
+    let mut frames = Vec::new();
+    let mut lines = raw.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        let Some((index, symbol)) = parse_frame(line.trim_start()) else {
+            continue;
+        };
+
+        // A frame's source location is rendered on the following `at <path>` line.
+        let location = match lines.peek() {
+            Some(next) if next.trim_start().starts_with("at ") => {
+                Some(lines.next().unwrap().trim_start())
+            }
+            _ => None,
+        };
+
+        frames.push(BacktraceFrame {
+            index,
+            symbol,
+            location,
+        });
+    }
+
+    frames
+}
+
+/// Parses a backtrace frame header line of the form `<index>: <symbol>` into its
+/// original frame offset and demangled symbol, returning `None` for other lines.
+fn parse_frame(line: &str) -> Option<(usize, &str)> {
+    let (index, symbol) = line.split_once(": ")?;
+    Some((index.parse().ok()?, symbol))
+}
+
+/// Returns `true` if `symbol` starts with any of the provided prefixes.
+fn starts_with_any(symbol: &str, prefixes: &[&str]) -> bool {
+    prefixes.iter().any(|prefix| symbol.starts_with(prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simplify_text() {
+        let raw = "\
+   0: std::backtrace_rs::backtrace::libunwind::trace
+             at /rustc/library/std/src/backtrace.rs:1
+   1: std::backtrace::Backtrace::create
+             at /rustc/library/std/src/backtrace.rs:2
+   2: human_errors::error::Error::new
+             at ./src/error.rs:57
+   3: human_errors::helpers::wrap_system
+             at ./src/helpers.rs:110
+   4: my_app::do_work
+             at ./src/main.rs:20
+   5: my_app::main
+             at ./src/main.rs:10
+   6: core::ops::function::FnOnce::call_once
+             at /rustc/library/core/src/ops/function.rs:250
+   7: std::rt::lang_start_internal
+             at /rustc/library/std/src/rt.rs:175
+   8: main";
+
+        let simplified = simplify_text(raw);
+
+        // The capture machinery and human_errors frames at the top are dropped
+        // and replaced with a single annotation, while surviving frames keep
+        // their original offsets.
+        assert!(!simplified.contains("std::backtrace"));
+        assert!(!simplified.contains("human_errors::"));
+        assert!(simplified.contains("... skipped 4 frames ..."));
+        assert!(simplified.contains(" 4: my_app::do_work"));
+
+        // Application frames keep their file paths.
+        assert!(simplified.contains("at ./src/main.rs:20"));
+
+        // core::* and std::* frames keep their symbol but lose their file path.
+        assert!(simplified.contains("core::ops::function::FnOnce::call_once"));
+        assert!(simplified.contains("std::rt::lang_start_internal"));
+        assert!(!simplified.contains("at /rustc/library/core/src/ops/function.rs:250"));
+        assert!(!simplified.contains("at /rustc/library/std/src/rt.rs:175"));
+
+        // A frame without a location line is still preserved.
+        assert!(simplified.contains("main\n"));
+    }
+
+    #[test]
+    fn test_simplify_text_strips_runtime_frames() {
+        let raw = "\
+   0: human_errors::error::Error::new
+             at ./src/error.rs:57
+   1: my_app::main
+             at ./src/main.rs:10
+   2: core::ops::function::FnOnce::call_once
+             at /rustc/library/core/src/ops/function.rs:250
+   3: std::sys::backtrace::__rust_begin_short_backtrace
+             at /rustc/library/std/src/sys/backtrace.rs:154
+   4: std::rt::lang_start_internal
+             at /rustc/library/std/src/rt.rs:175
+   5: main
+   6: BaseThreadInitThunk
+   7: RtlUserThreadStart";
+
+        let simplified = simplify_text(raw);
+
+        // The user's code is retained with its original offset.
+        assert!(simplified.contains(" 1: my_app::main"));
+        assert!(simplified.contains("core::ops::function::FnOnce::call_once"));
+
+        // Everything from the runtime boundary toward the bottom is dropped and
+        // replaced with an annotation (5 frames: the marker plus 4 below it).
+        assert!(!simplified.contains("__rust_begin_short_backtrace"));
+        assert!(!simplified.contains("std::rt::lang_start_internal"));
+        assert!(!simplified.contains("BaseThreadInitThunk"));
+        assert!(!simplified.contains("RtlUserThreadStart"));
+        assert!(simplified.contains("... skipped 5 frames ..."));
+    }
+
+    #[test]
+    fn test_simplify_text_falls_back_when_empty() {
+        let raw = "not a recognisable backtrace";
+        assert_eq!(simplify_text(raw), raw);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -244,13 +244,21 @@ impl Error {
     /// println!("{}", err.message_with_backtrace());
     /// ```
     pub fn message_with_backtrace(&self) -> String {
-        let mut message = self.message();
-
-        for (description, backtrace) in self.backtraces() {
-            message.push_str(&format!("\n\nBacktrace ({description}):\n{backtrace}"));
+        #[cfg(not(feature = "backtraces"))]
+        {
+            self.message()
         }
 
-        message
+        #[cfg(feature = "backtraces")]
+        {
+            let mut message = self.message();
+
+            for (description, backtrace) in crate::backtraces::collect(self) {
+                message.push_str(&format!("\n\nBacktrace ({description}):\n{backtrace}"));
+            }
+
+            message
+        }
     }
 
     /// Gets the backtrace associated with this error, if available.
@@ -273,39 +281,6 @@ impl Error {
     /// }
     pub fn backtrace(&self) -> Option<&std::backtrace::Backtrace> {
         self.backtrace.as_ref()
-    }
-
-    /// Collects the captured backtraces for this error and its causal chain.
-    ///
-    /// Walks this error and each causal [`Error`] which recorded a backtrace,
-    /// pairing every captured backtrace with the description of the error it
-    /// belongs to. Errors without a successfully captured backtrace (for
-    /// example when the `backtraces` feature is disabled) are skipped.
-    pub(crate) fn backtraces(&self) -> Vec<(String, &std::backtrace::Backtrace)> {
-        let mut backtraces = Vec::new();
-
-        if let Some(backtrace) = self.captured_backtrace() {
-            backtraces.push((self.description(), backtrace));
-        }
-
-        let mut cause: Option<&(dyn error::Error + 'static)> = Some(self.error.as_ref());
-        while let Some(err) = cause {
-            if let Some(err) = err.downcast_ref::<Error>() {
-                if let Some(backtrace) = err.captured_backtrace() {
-                    backtraces.push((err.description(), backtrace));
-                }
-            }
-
-            cause = err.source();
-        }
-
-        backtraces
-    }
-
-    fn captured_backtrace(&self) -> Option<&std::backtrace::Backtrace> {
-        self.backtrace
-            .as_ref()
-            .filter(|backtrace| backtrace.status() == std::backtrace::BacktraceStatus::Captured)
     }
 
     fn caused_by(&self) -> Vec<String> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -217,6 +217,42 @@ impl Error {
         }
     }
 
+    /// Gets the formatted error, its advice, and any captured backtraces.
+    ///
+    /// Behaves like [`Error::message`], but additionally appends the backtrace
+    /// captured for this error as well as the backtrace of each causal error
+    /// which recorded one. This is primarily useful when diagnosing system
+    /// failures, where the backtraces can help pinpoint where the problem
+    /// originated.
+    ///
+    /// Backtraces are only included when the `backtraces` (or `force_backtraces`)
+    /// feature is enabled and a backtrace was successfully captured (which
+    /// usually requires the `RUST_BACKTRACE` environment variable to be set).
+    /// When no backtraces are available, this method returns the same output as
+    /// [`Error::message`].
+    ///
+    /// # Examples
+    /// ```
+    /// use human_errors;
+    ///
+    /// let err = human_errors::system(
+    ///   "We could not connect to the database.",
+    ///   &["Check that the database is running and reachable."],
+    /// );
+    ///
+    /// // Prints the human-readable message followed by any captured backtraces.
+    /// println!("{}", err.message_with_backtrace());
+    /// ```
+    pub fn message_with_backtrace(&self) -> String {
+        let mut message = self.message();
+
+        for (description, backtrace) in self.backtraces() {
+            message.push_str(&format!("\n\nBacktrace ({description}):\n{backtrace}"));
+        }
+
+        message
+    }
+
     /// Gets the backtrace associated with this error, if available.
     ///
     /// Returns `Some` if the `backtraces` feature is enabled and a backtrace was captured when this error was created, otherwise returns `None`.
@@ -237,6 +273,39 @@ impl Error {
     /// }
     pub fn backtrace(&self) -> Option<&std::backtrace::Backtrace> {
         self.backtrace.as_ref()
+    }
+
+    /// Collects the captured backtraces for this error and its causal chain.
+    ///
+    /// Walks this error and each causal [`Error`] which recorded a backtrace,
+    /// pairing every captured backtrace with the description of the error it
+    /// belongs to. Errors without a successfully captured backtrace (for
+    /// example when the `backtraces` feature is disabled) are skipped.
+    pub(crate) fn backtraces(&self) -> Vec<(String, &std::backtrace::Backtrace)> {
+        let mut backtraces = Vec::new();
+
+        if let Some(backtrace) = self.captured_backtrace() {
+            backtraces.push((self.description(), backtrace));
+        }
+
+        let mut cause: Option<&(dyn error::Error + 'static)> = Some(self.error.as_ref());
+        while let Some(err) = cause {
+            if let Some(err) = err.downcast_ref::<Error>() {
+                if let Some(backtrace) = err.captured_backtrace() {
+                    backtraces.push((err.description(), backtrace));
+                }
+            }
+
+            cause = err.source();
+        }
+
+        backtraces
+    }
+
+    fn captured_backtrace(&self) -> Option<&std::backtrace::Backtrace> {
+        self.backtrace
+            .as_ref()
+            .filter(|backtrace| backtrace.status() == std::backtrace::BacktraceStatus::Captured)
     }
 
     fn caused_by(&self) -> Vec<String> {
@@ -354,6 +423,35 @@ mod tests {
         #[cfg(not(feature = "backtraces"))]
         {
             assert!(err.backtrace().is_none());
+        }
+    }
+
+    #[test]
+    fn test_message_with_backtrace() {
+        let err = crate::wrap_system(
+            crate::system("Inner failure.", &["Check inner systems"]),
+            "Outer failure.",
+            &["Check outer configuration"],
+        );
+
+        let message = err.message_with_backtrace();
+
+        // The human-readable message is always the prefix of the output.
+        assert!(message.starts_with(&err.message()));
+
+        #[cfg(feature = "force_backtraces")]
+        {
+            // Both the outer and inner errors captured a backtrace, so both are
+            // rendered recursively.
+            assert_eq!(message.matches("Backtrace (").count(), 2);
+            assert!(message.contains("Backtrace (Outer failure.):"));
+            assert!(message.contains("Backtrace (Inner failure.):"));
+        }
+
+        #[cfg(not(feature = "backtraces"))]
+        {
+            // With no backtraces available the output matches `message`.
+            assert_eq!(message, err.message());
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ mod pretty;
 mod result;
 mod wrapper;
 
+#[cfg(feature = "backtraces")]
+mod backtraces;
+
 pub use error::*;
 pub use helpers::*;
 pub use kind::*;

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -126,7 +126,8 @@ impl Display for Renderer<'_> {
         }
 
         if self.backtraces {
-            for (description, backtrace) in self.error.backtraces() {
+            #[cfg(feature = "backtraces")]
+            for (description, backtrace) in crate::backtraces::collect(self.error) {
                 writeln!(f)?;
                 write_box(
                     f,

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -23,12 +23,43 @@ pub fn pretty(err: &Error) -> impl Display {
     Renderer {
         error: err,
         width: 80,
+        backtraces: false,
+    }
+}
+
+/// Returns a displayable representation of the given error, including backtraces.
+///
+/// Behaves like [`pretty`], but additionally renders the backtrace captured for
+/// the error as well as the backtrace of each causal error which recorded one.
+///
+/// Backtraces are only rendered when the `backtraces` (or `force_backtraces`)
+/// feature is enabled and a backtrace was successfully captured (which usually
+/// requires the `RUST_BACKTRACE` environment variable to be set). When no
+/// backtraces are available, this produces the same output as [`pretty`].
+///
+/// # Examples
+/// ```no_run
+/// use human_errors;
+///
+/// let err = human_errors::system(
+///   "We could not connect to the database.",
+///   &["Check that the database is running and reachable."],
+/// );
+///
+/// println!("{}", human_errors::pretty_with_backtraces(&err));
+/// ```
+pub fn pretty_with_backtraces(err: &Error) -> impl Display {
+    Renderer {
+        error: err,
+        width: 120,
+        backtraces: true,
     }
 }
 
 struct Renderer<'a> {
     error: &'a Error,
     width: usize,
+    backtraces: bool,
 }
 
 impl Display for Renderer<'_> {
@@ -41,8 +72,10 @@ impl Display for Renderer<'_> {
             f,
             self.error.description(),
             self.width - 14,
+            0,
+            " ".repeat(14),
             ("", ""),
-            (&format!("{}{}", "│".bright_black(), " ".repeat(14)), ""),
+            (&format!("{}{}", "│".bright_black(), ""), ""),
         )?;
 
         let mut source = self.error.source();
@@ -72,11 +105,10 @@ impl Display for Renderer<'_> {
                 f,
                 description,
                 self.width - 14,
+                0,
+                " ".repeat(14),
                 ("".bright_black().as_ref(), ""),
-                (
-                    &format!("{}{}", "│".bright_black(), " ".repeat(13)).bright_black(),
-                    "",
-                ),
+                (&format!("{}{}", "│".bright_black(), "").bright_black(), ""),
             )?;
         }
 
@@ -91,6 +123,19 @@ impl Display for Renderer<'_> {
                 cli_boxes::BoxChars::ROUND,
                 self.width,
             )?;
+        }
+
+        if self.backtraces {
+            for (description, backtrace) in self.error.backtraces() {
+                writeln!(f)?;
+                write_box(
+                    f,
+                    "Backtrace",
+                    format!("{description}\n\n{backtrace}"),
+                    cli_boxes::BoxChars::ROUND,
+                    self.width,
+                )?;
+            }
         }
 
         Ok(())
@@ -110,13 +155,21 @@ fn write_wrapped<D: Display + Copy>(
     f: &mut std::fmt::Formatter<'_>,
     content: impl AsRef<str>,
     width: usize,
+    padding: usize,
+    indent: impl AsRef<str>,
     first_line: (D, D),
     other_lines: (D, D),
 ) -> std::fmt::Result {
     use colored::Colorize;
 
     let mut first = true;
-    for chunk in textwrap::wrap(content.as_ref(), width) {
+    let padding_str = " ".repeat(padding);
+    for chunk in textwrap::wrap(
+        content.as_ref(),
+        textwrap::Options::new(width - 2 * padding)
+            .break_words(true)
+            .subsequent_indent(indent.as_ref()),
+    ) {
         let (prefix, suffix) = if first {
             first = false;
             first_line
@@ -125,11 +178,9 @@ fn write_wrapped<D: Display + Copy>(
         };
         writeln!(
             f,
-            "{}{}{}{}",
-            prefix,
+            "{prefix}{padding_str}{}{}{padding_str}{suffix}",
             chunk.bright_white(),
-            " ".repeat(width.saturating_sub(chunk.len())),
-            suffix
+            " ".repeat(width.saturating_sub(chunk.chars().count())),
         )?;
     }
 
@@ -164,7 +215,9 @@ fn write_box(
         write_wrapped(
             f,
             line,
-            width,
+            width - 4,
+            1,
+            "  ",
             (&box_chars.left, &box_chars.right),
             (&box_chars.left, &box_chars.right),
         )?;
@@ -236,5 +289,34 @@ mod tests {
         assert!(rendered.contains("underlying IO error"));
         assert!(rendered.contains("Ensure the file exists and is readable."));
         assert!(rendered.contains("Check your configuration settings."));
+    }
+
+    #[test]
+    fn test_renderer_with_backtraces() {
+        let err = wrap_system(
+            system("Inner failure.", &["Check inner systems"]),
+            "Outer failure.",
+            &["Check outer configuration"],
+        );
+
+        let rendered = format!("{}", pretty_with_backtraces(&err));
+
+        println!("{}", rendered);
+
+        assert!(rendered.contains("Outer failure."));
+
+        // The default renderer never emits backtraces.
+        let plain = format!("{}", pretty(&err));
+        assert!(!plain.contains("Backtrace"));
+
+        #[cfg(feature = "force_backtraces")]
+        {
+            // A backtrace box is rendered for both the outer and inner errors,
+            // adding two boxes on top of whatever the plain renderer produced.
+            assert_eq!(
+                rendered.matches('╭').count(),
+                plain.matches('╭').count() + 2
+            );
+        }
     }
 }


### PR DESCRIPTION
## Overview

Adds first-class support for rendering errors together with their backtraces, and makes those backtraces concise and readable rather than a wall of runtime noise.

## What's included

### New APIs
- `Error::message_with_backtrace()` — like `message()`, but appends the captured backtrace for the error and each causal error that recorded one (rendered recursively).
- `pretty_with_backtraces(&err)` — like `pretty()`, but renders a `Backtrace` box per causal error that captured one.

Both gracefully fall back to their non-backtrace equivalents when the `backtraces`/`force_backtraces` feature is disabled or no trace was captured.

### Backtrace simplification
Captured backtraces are filtered for readability:
- Skip the capture machinery (`std::backtrace*`) and `human_errors::*` frames at the top of the stack, so the trace starts at the caller that created the error.
- Drop the runtime/OS bootstrap frames at the bottom, cutting at the `__rust_begin_short_backtrace` boundary where user code begins executing (the same marker Rust uses for its own short backtraces).
- Strip file-path lines from `core::*` and `std::*` frames.
- Replace skipped ranges with a `... skipped N frames ...` annotation, while retaining the original frame offsets.

Before → after (example):
```
   0: std::backtrace_rs::backtrace::win64::trace
             at /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library\std\src\..\..\backtrace\src\backtrace\win64.rs:85
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library\std\src\..\..\backtrace\src\backtrace\mod.rs:66
   2: std::backtrace::Backtrace::create
             at /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library\std\src\backtrace.rs:331
   3: std::backtrace::Backtrace::force_capture
             at /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library\std\src\backtrace.rs:312
   4: human_errors::error::Error::new<human_errors::wrapper::ErrorWithMessage>
             at .\src\error.rs:57
   5: human_errors::helpers::wrap_user<ref$<str$>,human_errors::error::Error>
             at .\src\helpers.rs:56
   6: backtraces::build_error
             at .\examples\backtraces.rs:24
   7: backtraces::main
             at .\examples\backtraces.rs:10
   8: core::ops::function::FnOnce::call_once<void (*)(),tuple$<> >
             at C:\Users\BenjaminPannell\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:250
   9: std::sys::backtrace::__rust_begin_short_backtrace<void (*)(),tuple$<> >
             at C:\Users\BenjaminPannell\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\sys\backtrace.rs:166
  10: std::rt::lang_start::closure$0<tuple$<> >
             at C:\Users\BenjaminPannell\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\rt.rs:206
  11: std::rt::lang_start_internal::closure$0
             at /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library\std\src\rt.rs:175
  12: std::panicking::catch_unwind::do_call
             at /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library\std\src\panicking.rs:581
  13: std::panicking::catch_unwind
             at /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library\std\src\panicking.rs:544
  14: std::panic::catch_unwind
             at /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library\std\src\panic.rs:359
  15: std::rt::lang_start_internal
             at /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library\std\src\rt.rs:171
  16: std::rt::lang_start<tuple$<> >
             at C:\Users\BenjaminPannell\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\rt.rs:205
  17: main
  18: invoke_main
             at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
  19: __scrt_common_main_seh
             at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
  20: BaseThreadInitThunk
  21: RtlUserThreadStart
```
```
    ... skipped 6 frames ...
 6: backtraces::build_error
    at .\examples\backtraces.rs:24
 7: backtraces::main
    at .\examples\backtraces.rs:10
 8: core::ops::function::FnOnce::call_once<void (*)(),tuple$<> >
    ... skipped 13 frames ...
```

### Module extraction
All backtrace parsing/processing lives in a new `backtraces` module that is only compiled when the `backtraces` feature is enabled. `message_with_backtrace` and the pretty renderer call `backtraces::collect` directly.

### Examples
Three preview binaries under `examples/`, registered with matching `required-features`:
- `default` — plain-text output
- `pretty` — CLI-formatted output (`--features pretty`)
- `backtraces` — both formats with backtraces (`--features pretty,force_backtraces`)

## Testing
- Deterministic unit tests for the simplification rules (top/bottom trimming, path stripping, annotations, original offsets, fallback).
- Tests for the new rendering APIs.
- Verified warning-free builds and passing tests across `default`, `pretty`, `backtraces`, and `--all-features`.